### PR TITLE
Return vertical qp gain crop to original values

### DIFF
--- a/fgo_mat_counter.py
+++ b/fgo_mat_counter.py
@@ -257,7 +257,7 @@ def extract_text_from_image(image, file_name='pytesseract_input.png'):
 
 
 def get_qp(image):
-    qp_gained_text = extract_text_from_image(image[432:432 + 38, 230:230 + 300], 'qp_gained_text.png')
+    qp_gained_text = extract_text_from_image(image[435:435 + 38, 230:230 + 300], 'qp_gained_text.png')
     logging.info(f'QP gained text: {qp_gained_text}')
     qp_total_text = extract_text_from_image(image[481:481 + 38, 212:212 + 282], 'qp_total_text.png')
     logging.info(f'QP total text: {qp_total_text}')


### PR DESCRIPTION
I must have thought 2 was 5 since my [original intention](https://github.com/atlasacademy/capy-drop-parser/pull/11/files#diff-b6f11f4e305da9a0985c665f288dac73L260) was to have the same numbers before and after the colon.